### PR TITLE
Update v1.0.0

### DIFF
--- a/modules/getweblinks.py
+++ b/modules/getweblinks.py
@@ -31,10 +31,15 @@ def getLinks(soup,ext):
         print (bcolors.OKGREEN+'Websites Found - '+bcolors.ENDC+str(len(websites)))
         print ('-------------------------------')
         for web in websites:
-            if (urllib.request.urlopen(web).getcode() == 200):
-                print (web)
-            else :
-                print(bcolors.On_Red+web +bcolors.ENDC)    
+            flag=1
+            try:
+                urllib.request.urlopen(web)    
+            except urllib.error.HTTPError as e:
+                if e.code:
+                    print(bcolors.On_Red+web+bcolors.ENDC)
+                    flag=0  
+            if flag:
+                print(web)          
         return websites
     else:
         raise('Method parameter is not of instance bs4.BeautifulSoup')

--- a/modules/getweblinks.py
+++ b/modules/getweblinks.py
@@ -22,7 +22,7 @@ def getLinks(soup):
                 pass
         """Pretty print output as below"""
         print ('') 
-        print ('Websites Found - '+str(len(websites)))
+        print (bcolors.OKGREEN+'Websites Found - '+bcolors.ENDC+str(len(websites)))
         print ('-------------------------------')
         for web in websites:
             if (urllib.request.urlopen(web).getcode() == 200):

--- a/modules/getweblinks.py
+++ b/modules/getweblinks.py
@@ -6,18 +6,24 @@ from modules.bcolors import bcolors
 import bs4
 
 """Get all onion links from the website"""
-def getLinks(soup):
+def getLinks(soup,ext):
     _soup_instance = bs4.BeautifulSoup
-    extensions = ['.onion','.onion/']
+    extensions = []
+    if ext:
+        for e in ext:
+            extensions.append(e)  
     if isinstance(type(soup), type(_soup_instance)):
         websites = []
         for link in soup.find_all('a'):
             web_link = link.get('href')
             if web_link != None:
-                if 'http' in web_link:
-                    for extension in extensions:
-                        if web_link.endswith(extension):
-                            websites.append(web_link)
+                if ('http' in web_link or 'https' in web_link):
+                    if ext:
+                        for exten in extensions:
+                            if web_link.endswith(exten):
+                                websites.append(web_link)
+                    else:
+                        websites.append(web_link)            
             else:
                 pass
         """Pretty print output as below"""

--- a/modules/pagereader.py
+++ b/modules/pagereader.py
@@ -1,12 +1,16 @@
 import urllib.request 
 from bs4 import BeautifulSoup
+from modules.bcolors import bcolors
 
 
-def readPage(site):
+def readPage(site,printIP=0):
 
  headers = {'User-Agent': 'TorBot - Onion crawler | www.github.com/DedSecInside/TorBot' }
  req = urllib.request.Request(site,None,headers)
  response = urllib.request.urlopen(req)
  page = BeautifulSoup(response.read(),'html.parser')
- print (page.find_all('strong'))
+ if printIP:
+  pg = page.find('strong')
+  IP = pg.renderContents()
+  print(bcolors.WARNING+bcolors.BOLD+IP.decode("utf-8")+bcolors.ENDC)
  return page

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.6.0
-SocksiPy_branch==1.01
+PySocks==1.6.7
 stem==1.5.4

--- a/tests/test_getweblinks.py
+++ b/tests/test_getweblinks.py
@@ -16,7 +16,7 @@ class getLinksTestCase(unittest.TestCase):
 	
 	def test_print_links(self):
 		#data = "\nWebsites Found - 7\n-------------------------------\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIP856a6b4\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIPbf5d683\nhttp://aff.ironsocket.com/SH7L\nhttp://aff.ironsocket.com/SH7L\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIPdb5f512\nhttp://wsrs.net/\nhttp://cmsgear.com/\n"
-		data = "\nWebsites Found - 0\n-------------------------------\n"
+		data = "\n"+bcolors.OKGREEN+"Websites Found - "+bcolors.ENDC+"0\n-------------------------------\n"
 
 		getweblinks.getLinks(soup)
 		self.assertEqual(sys.stdout.getvalue(),data)

--- a/tests/test_getweblinks.py
+++ b/tests/test_getweblinks.py
@@ -13,12 +13,13 @@ class getLinksTestCase(unittest.TestCase):
 	
 	def setUp(self):
 		self.held, sys.stdout = sys.stdout, StringIO()
+		self.maxDiff=None
 	
 	def test_print_links(self):
 		#data = "\nWebsites Found - 7\n-------------------------------\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIP856a6b4\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIPbf5d683\nhttp://aff.ironsocket.com/SH7L\nhttp://aff.ironsocket.com/SH7L\nhttp://ads.wsrs.net/www/delivery/ck.php?n=MyIPdb5f512\nhttp://wsrs.net/\nhttp://cmsgear.com/\n"
-		data = "\n"+bcolors.OKGREEN+"Websites Found - "+bcolors.ENDC+"0\n-------------------------------\n"
-
-		getweblinks.getLinks(soup)
+		data = "\n"+bcolors.OKGREEN+"Websites Found - "+bcolors.ENDC+"1\n-------------------------------\nhttp://cmsgear.com/\n"
+		ext = ['.com/']
+		getweblinks.getLinks(soup,ext)
 		self.assertEqual(sys.stdout.getvalue(),data)
 
 

--- a/torBot.py
+++ b/torBot.py
@@ -58,17 +58,17 @@ def header():
 	print( "MMMMMMMMMMMMMWNklccclldk0OxOdcc;. .......;oKWWMMMMMMMM")
 	print( "MMMMMMMMMMMMMMMMWXOdl:::;cc;'... ..',:lx0NMMMMMMMMMMMM")
 	print( "MMMMMMMMMMMMMMMMMMMMMNKOkxddolloodk0XWMMMMMMMMMMMMMMMM")
-	print(bcolors.FAIL)
+	print(bcolors.FAIL+bcolors.BOLD)
 	print( " 	       __  ____  ____  __        ______ ")
 	print( "  	      / /_/ __ \/ __ \/ /_  ____/_  __/ ")
 	print( " 	     / __/ / / / /_/ / __ \/ __ \/ / ")
 	print( "	    / /_/ /_/ / _, _/ /_/ / /_/ / /  ")
 	print( "	    \__/\____/_/ |_/_.___/\____/_/  V 0.0.3")
-	print(bcolors.On_Black)
+	print(bcolors.FAIL+bcolors.On_Black)
 	print("#######################################################")
 	print("#  TorBot - A python Tor Crawler                      #")
 	print("#  GitHub : https://github.com/DedsecInside/TorBot    #")
-	print("######################################################")
+	print("#######################################################")
 	print(bcolors.FAIL + "LICENSE: GNU Public License" + bcolors.ENDC)
 	print()
    
@@ -76,7 +76,7 @@ def header():
 def main():
  header()
  print ("Tor Ip Address :")
- a = readPage("https://check.torproject.org/")
+ a = readPage("https://check.torproject.org/",1)
  b = readPage("http://torlinkbgs6aabns.onion/")
  getMails(b)
  getLinks(b)
@@ -89,5 +89,3 @@ if __name__ == '__main__':
   main()
  except KeyboardInterrupt:
   print("Interrupt received! Exiting cleanly...")
- 
-  	

--- a/torBot.py
+++ b/torBot.py
@@ -63,7 +63,7 @@ def header():
 	print( "  	      / /_/ __ \/ __ \/ /_  ____/_  __/ ")
 	print( " 	     / __/ / / / /_/ / __ \/ __ \/ / ")
 	print( "	    / /_/ /_/ / _, _/ /_/ / /_/ / /  ")
-	print( "	    \__/\____/_/ |_/_.___/\____/_/  V 0.0.3")
+	print( "	    \__/\____/_/ |_/_.___/\____/_/  V 1.0.0")
 	print(bcolors.FAIL+bcolors.On_Black)
 	print("#######################################################")
 	print("#  TorBot - A python Tor Crawler                      #")
@@ -74,12 +74,26 @@ def header():
    
 
 def main():
- header()
+ parser = argparse.ArgumentParser()
+ parser.add_argument("-q","--quiet",action="store_true")
+ parser.add_argument("-u","--url",help="Specifiy a website link to crawl")
+ parser.add_argument("-m","--mail",action="store_true", help="Get e-mail addresses from the crawled sites.")
+ parser.add_argument("-e","--extension",action='append',dest='extension',default=[],help="Specifiy additional website extensions to the list(.com or .org etc)")
+ args = parser.parse_args()	
+ if args.quiet == 0:
+ 	header()
  print ("Tor Ip Address :")
+ link = args.url
+ ext = 0
+ ext = args.extension
  a = readPage("https://check.torproject.org/",1)
- b = readPage("http://torlinkbgs6aabns.onion/")
- getMails(b)
- getLinks(b)
+ if link:
+ 	b = readPage(link)
+ else:
+    b = readPage("http://torlinkbgs6aabns.onion/")
+ if args.mail:
+ 	getMails(b)
+ getLinks(b,ext)
  print ("\n\n")
  return 0
 


### PR DESCRIPTION
* Added argument parser
```
python3 torBot.py -h
usage: torBot.py [-h] [-q] [-u URL] [-m] [-e EXTENSION]

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet
  -u URL, --url URL     Specifiy a website link to crawl
  -m, --mail            Get e-mail addresses from the crawled sites.
  -e EXTENSION, --extension EXTENSION
                        Specifiy additional website extensions to the
                        list(.com or .org etc)
```
