### PR TITLE
Title feature added

### DIFF
--- a/modules/getweblinks.py
+++ b/modules/getweblinks.py
@@ -53,7 +53,7 @@ def valid_onion_url(url):
     return False
 
 
-def get_link_status(link):
+def is_link_alive(link):
     """Generator that yields links as they come
 
         Uses head request because it uses less bandwith than get and timeout is
@@ -74,13 +74,18 @@ def get_link_status(link):
     except (ConnectionError, HTTPError):
         return False
 
-def addColorToLinks(link, colors):
-    if get_link_status(link):
-        return '\t'+link
+
+def add_green(link):
+    colors = Bcolors()
+    return '\t'+ colors.OKGREEN + link + colors.ENDC
+
+
+def add_red(link):
+    colors = Bcolors()
     return '\t' + colors.On_Red + link + colors.ENDC
 
 
-def getLinks(soup, ext=False, live=False):
+def get_links(soup, ext=False, live=False):
     """
         Searches through all <a ref> (hyperlinks) tags and stores them in a
         list then validates if the url is formatted correctly.
@@ -111,13 +116,14 @@ def getLinks(soup, ext=False, live=False):
         print('------------------------------------')
 
         for link in websites:
-            if get_link_status(link):
-                coloredLink = addColorToLinks(link, b_colors)
-                page = pagereader.readPage(link)
+            if is_link_alive(link):
+                coloredlink = add_green(link)
+                page = pagereader.read_page(link)
                 if page is not None and page.title is not None:
-                    printRow(b_colors.OKGREEN + coloredLink + b_colors.ENDC, page.title.string)
+                    print_row(coloredlink, page.title.string)
             else:
-                printRow('\t' + b_colors.On_Red + link + b_colors.ENDC, "Not found")
+                coloredlink = add_red(link)
+                print_row(coloredlink, "Not found")
 
         return websites
 
@@ -126,6 +132,6 @@ def getLinks(soup, ext=False, live=False):
         raise(Exception('Method parameter is not of instance BeautifulSoup'))
 
 
-def printRow(url, description):
+def print_row(url, description):
     print("%-80s %-30s" % (url, description))
 

--- a/modules/info.py
+++ b/modules/info.py
@@ -4,7 +4,7 @@ from urllib.parse import urlsplit
 from termcolor import cprint
 
 
-def executeAll(target):
+def executeAll(target, soup):
     try:
         get_robots_txt(target)
     except Exception:
@@ -21,6 +21,7 @@ def executeAll(target):
         get_dot_htaccess(target)
     except Exception:
         cprint("Error""red")
+    #TODO: get_webpage_title()
 
 
 def get_robots_txt(target):
@@ -71,3 +72,7 @@ def get_dot_htaccess(target):
     else:
         cprint("Status code"'blue')
         cprint(statcode)
+
+
+
+#def get_webpage_title(target, soup):

--- a/modules/pagereader.py
+++ b/modules/pagereader.py
@@ -18,21 +18,21 @@ def readPage(site, extension=False):
     while attempts_left:
         try:
             if not extension:
-                print(next(connection_msg(site)))
+                #print(next(connection_msg(site)))
                 response = requests.get(site, headers=headers)
-                print("Connection successful.")
+                #print("Connection successful.")
                 page = BeautifulSoup(response.text, 'html.parser')
                 return page
             if extension and attempts_left == 3:
-                print(next(connection_msg('https://'+site)))
+                #print(next(connection_msg('https://'+site)))
                 response = requests.get('https://'+site, headers=headers)
-                print("Connection successful.")
+                #print("Connection successful.")
                 page = BeautifulSoup(response.text, 'html.parser')
                 return page
             if extension and attempts_left == 2:
-                print(next(connection_msg('http://'+site)))
+                #print(next(connection_msg('http://'+site)))
                 response = requests.get('http://'+site, headers=headers)
-                print("Connection successful.")
+                #print("Connection successful.")
                 page = BeautifulSoup(response.text, 'html.parser')
                 return page
             if extension and attempts_left == 1:

--- a/modules/pagereader.py
+++ b/modules/pagereader.py
@@ -10,7 +10,47 @@ def connection_msg(site):
     yield "Attempting to connect to {site}".format(site=site)
 
 
-def readPage(site, extension=False):
+def read_first_page(site, extension=False):
+    headers = {'User-Agent':
+               'TorBot - Onion crawler | www.github.com/DedSecInside/TorBot'}
+    attempts_left = 3
+    err = " "
+    while attempts_left:
+        try:
+            if not extension:
+                print(next(connection_msg(site)))
+                response = requests.get(site, headers=headers)
+                print("Connection successful.")
+                page = BeautifulSoup(response.text, 'html.parser')
+                return page
+            if extension and attempts_left == 3:
+                print(next(connection_msg('https://'+site)))
+                response = requests.get('https://'+site, headers=headers)
+                print("Connection successful.")
+                page = BeautifulSoup(response.text, 'html.parser')
+                return page
+            if extension and attempts_left == 2:
+                print(next(connection_msg('http://'+site)))
+                response = requests.get('http://'+site, headers=headers)
+                print("Connection successful.")
+                page = BeautifulSoup(response.text, 'html.parser')
+                return page
+            if extension and attempts_left == 1:
+                msg = ''.join(("There has been an {err} while attempting to ",
+                              "connect to {site}.")).format(err=err, site=site)
+                exit(msg)
+
+        except (HTTPError, ConnectionError) as e:
+            attempts_left -= 1
+            err = e
+
+    if err == HTTPError:
+        raise("There has been an HTTP error after three attempts.")
+    if err == ConnectionError:
+        raise("There has been a connection error after three attempts.")
+
+
+def read_page(site, extension=False):
     headers = {'User-Agent':
                'TorBot - Onion crawler | www.github.com/DedSecInside/TorBot'}
     attempts_left = 3
@@ -58,7 +98,7 @@ def get_ip():
     """
 
     b_colors = Bcolors()
-    page = readPage('https://check.torproject.org/')
+    page = read_first_page('https://check.torproject.org/')
     pg = page.find('strong')
     ip_addr = pg.renderContents()
 

--- a/tests/test_getemails.py
+++ b/tests/test_getemails.py
@@ -11,7 +11,7 @@ from modules import pagereader, getemails
 
 
 def test_get_emails_successful():
-    soup = pagereader.readPage('https://www.helloaddress.com/')
+    soup = pagereader.read_first_page('https://www.helloaddress.com/')
     test_emails = ["hello@helloaddress.com"]
     emails = getemails.getMails(soup)
     assert emails == test_emails

--- a/tests/test_getweblinks.py
+++ b/tests/test_getweblinks.py
@@ -11,13 +11,13 @@ from modules import getweblinks, pagereader
 
 
 def test_get_links_successful():
-    soup = pagereader.readPage('http://www.whatsmyip.net/')
+    soup = pagereader.read_first_page('http://www.whatsmyip.net/')
     data = ['http://aff.ironsocket.com/SH7L',
             'http://aff.ironsocket.com/SH7L',
             'http://wsrs.net/',
             'http://cmsgear.com/']
 
-    result = getweblinks.getLinks(soup, ext=['.com', '.net'])
+    result = getweblinks.get_links(soup, ext=['.com', '.net'])
     assert result == data
 
 

--- a/torBot.py
+++ b/torBot.py
@@ -156,7 +156,7 @@ def main(conn=False):
     # additional flag can be set with -u/--url flag
     if args.url:
         print("Tor IP Address :", pagereader.get_ip())
-        html_content = pagereader.readPage(link, args.extension)
+        html_content = pagereader.read_first_page(link, args.extension)
         # -m/--mail
         if args.mail:
             emails = getemails.getMails(html_content)
@@ -169,9 +169,9 @@ def main(conn=False):
             if args.save:
                 print('Nothing to save.\n')
         else:
-            links = getweblinks.getLinks(soup=html_content,
-                                         live=args.live,
-                                         ext=args.extension)
+            links = getweblinks.get_links(soup=html_content,
+                                          live=args.live,
+                                          ext=args.extension)
             if args.save:
                 savefile.saveJson("Links", links)
     else:

--- a/torBot.py
+++ b/torBot.py
@@ -165,7 +165,7 @@ def main(conn=False):
                 savefile.saveJson('Emails', emails)
         # -i/--info
         elif args.info:
-            info.executeAll(link)
+            info.executeAll(link, html_content)
             if args.save:
                 print('Nothing to save.\n')
         else:


### PR DESCRIPTION
A new feature that allows you to quick read the title of the crawled website (if alive) has been added.
When a given link is passed with the 'u' flag, the program will return the h1 title of the page along with the url. 
 
A little refactor throughout the project has been carried out, in particular the "yield" construct at line 72 and 74 has been removed and replaced it with a simple return. 
To be honest I couldn't understand exactly why the programmer used this construct in the first place, therefore I want to point out here in order to be sure that I haven't broken anything. 

The feature has been tested thoroughly.
Regression testing has been made and it is okay. 