### PR TITLE
Mocking http requests for pagereader module test

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Read more about torrc here : [Torrc](https://github.com/DedSecInside/TorBoT/blob
 
 ## TO-DO
 - [ ] Implement A\* Search for webcrawler
+- [ ] Multithreading
+- [ ] Optimization
+- [ ] Randomize Tor Connection (Random Header and Identity)
 
 ### Have ideas?
 If you have new ideas which is worth implementing, mention those by starting a new issue with the title [FEATURE_REQUEST].

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PySocks==1.6.7
 termcolor==1.1.0
 requests==2.18.4
 tldextract==2.2.0
+requests_mock=1.4.0

--- a/tests/test_pagereader.py
+++ b/tests/test_pagereader.py
@@ -1,0 +1,56 @@
+import pytest
+import requests
+import requests_mock
+
+from bs4 import BeautifulSoup
+from requests.exceptions import HTTPError
+
+@pytest.fixture
+def test_read_first_page(site, extension=False):
+
+    with requests_mock.Mocker() as m: 
+        # Creating mock https requests
+        m.get('https://test_dotcom.com', text='This is a dot com site.')
+        m.get('https://test_dotonion.onion', text='This is a dot onion site.')
+        m.get('https://test_dotorg.org', text='This is a dot org site.')
+        m.get('https://test_dotnet.net', text='This is a dot net site.')
+        m.register_uri('GET', 'https://test_cannotbefound.cannotbefound', exc=HTTPError)
+
+        headers = {'User-Agent':
+                   'TorBot - Onion crawler | www.github.com/DedSecInside/TorBot'}
+        err = " "
+
+        # Removed all unneccssary functionality for testing such as printing
+        try:
+                response = requests.get('https://'+site, headers=headers)
+                page = BeautifulSoup(response.text, 'html.parser')
+                return page
+        except HTTPError as e:
+            raise e
+
+
+def test_single_extension():
+
+    urls = {
+            "test_dotcom.com":".com", 
+            "test_dotonion.onion":".onion",
+            "test_dotorg.org":".org",
+            "test_dotnet.net":".net",
+            "test_cannotbefound.cannotbefound":".cannotbefound"
+            }
+   
+    # Using context manager to catch error that will be raised
+    with pytest.raises(HTTPError):
+        for secondlevel_domain, toplevel_domain in urls.items():
+            page = test_read_first_page(secondlevel_domain, toplevel_domain)
+            if toplevel_domain == ".com":
+                assert str(page) == "This is a dot com site."
+            elif toplevel_domain == ".onion":
+                assert str(page) == "This is a dot onion site." 
+            elif toplevel_domain == ".org":
+                assert str(page) =="This is a dot org site."
+            elif toplevel_domain == ".net":
+                assert str(page) == "This is a dot net site."
+
+if __name__ == 'main':
+    test_single_extension()


### PR DESCRIPTION
I'm using requests_mock to make predefined responses to uris for the requests adapter so we don't have to use actual network connections for testing. Currently only test the case of a single extension but we can add more test for multiple extensions. This is just a base example. 