### PR TITLE
Fix cprints by adding commas separating text and color parameters

### DIFF
--- a/modules/info.py
+++ b/modules/info.py
@@ -9,27 +9,27 @@ def executeAll(target, soup, response):
     try:
         get_robots_txt(target)
     except Exception:
-        cprint("No robots.txt file Found!""blue")
+        cprint("No robots.txt file Found!", "blue")
     try:
         get_dot_git(target)
     except Exception:
-        cprint("Error !""red")
+        cprint("Error !", "red")
     try:
         get_dot_svn(target)
     except Exception:
-        cprint("Error""red")
+        cprint("Error", "red")
     try:
         get_dot_htaccess(target)
     except Exception:
-        cprint("Error""red")
+        cprint("Error", "red")
     try:
         get_webpage_description(soup)
     except Exception:
-        cprint("Error""red")
+        cprint("Error", "red")
     try:
         get_headers(response)
     except Exception:
-        cprint("Error""red")
+        cprint("Error", "red")
 
 
 def get_headers(response):
@@ -42,7 +42,7 @@ def get_headers(response):
 
 
 def get_robots_txt(target):
-    cprint("[*]Checking for Robots.txt"'yellow')
+    cprint("[*]Checking for Robots.txt", 'yellow')
     url = target
     target = "{0.scheme}://{0.netloc}/".format(urlsplit(url))
     requests.get(target+"/robots.txt")
@@ -50,49 +50,49 @@ def get_robots_txt(target):
 
 
 def get_dot_git(target):
-    cprint("[*]Checking for .git folder"'yellow')
+    cprint("[*]Checking for .git folder", 'yellow')
     url = target
     target = "{0.scheme}://{0.netloc}/".format(urlsplit(url))
     req = requests.get(target+"/.git/")
     r = req.status_code
     if r == 200:
-        cprint("Alert!"'red')
-        cprint(".git folder exposed publicly"'red')
+        cprint("Alert!", 'red')
+        cprint(".git folder exposed publicly", 'red')
     else:
-        print("NO .git folder found"'blue')
+        cprint("NO .git folder found", 'blue')
 
 
 def get_dot_svn(target):
-    cprint("[*]Checking for .svn folder"'yellow')
+    cprint("[*]Checking for .svn folder", 'yellow')
     url = target
     target = "{0.scheme}://{0.netloc}/".format(urlsplit(url))
     req = requests.get(target+"/.svn/entries")
     r = req.status_code
     if r == 200:
-        cprint("Alert!"'red')
-        cprint(".SVN folder exposed publicly"'red')
+        cprint("Alert!", 'red')
+        cprint(".SVN folder exposed publicly", 'red')
     else:
-        cprint("NO .SVN folder found"'blue')
+        cprint("NO .SVN folder found", 'blue')
 
 
 def get_dot_htaccess(target):
-    cprint("[*]Checking for .htaccess"'yellow')
+    cprint("[*]Checking for .htaccess", 'yellow')
     url = target
     target = "{0.scheme}://{0.netloc}/".format(urlsplit(url))
     req = requests.get(target+"/.htaccess")
     statcode = req.status_code
     if statcode == 403:
-        cprint("403 Forbidden"'blue')
+        cprint("403 Forbidden", 'blue')
     elif statcode == 200:
-        cprint("Alert!!"'blue')
-        cprint(".htaccess file found!"'blue')
+        cprint("Alert!!", 'blue')
+        cprint(".htaccess file found!", 'blue')
     else:
-        cprint("Status code"'blue')
+        cprint("Status code", 'blue')
         cprint(statcode)
 
 
 def get_webpage_description(soup):
-    cprint("[*]Checking for description meta tag"'yellow')
+    cprint("[*]Checking for description meta tag", 'yellow')
     metatags = soup.find_all('meta')
     for meta in metatags:
         if meta.has_attr('name'):


### PR DESCRIPTION
The PR fixes #131 

### Changes Proposed
Add commas to separate text and color parameters in `cprint` calls
Change one `print` to `cprint` as well
