### PR TITLE
Feature: extract title 

### DIFF
--- a/modules/analyzer.py
+++ b/modules/analyzer.py
@@ -10,11 +10,11 @@ from .getweblinks import get_urls_from_page
 from .pagereader import read
 
 
-class Node:
-    """Represents each webpage, has two attributes- one which has the url of the webpage and the other has the title (if mentioned) of the webpage """
-    def __init__(self, title="", link):
-        self.title=title 
-        self.link=link
+class CustomTree(Tree): #override the Tree class to add an attribute which'll hold the page name
+    def __init__(self,**kwargs, webPageName=""):
+        super().__init__(**kwargs) 
+        self.webPageName= webPageName
+
         
 class LinkTree:
     """
@@ -47,7 +47,8 @@ class LinkTree:
         style = TreeStyle()
         style.show_leaf_name = False
         def my_layout(node):
-            node_style = TextFace(node.name, tight_text=True)
+            string_to_represent_node= "{} \n {}".format(node.name, node.webPageName)
+            node_style = TextFace(string_to_represent_node, tight_text=True)
             add_face_to_node(node_style, node, column=0, position='branch-bottom')
         style.layout_fn = my_layout
         self._tree.render(file_name, tree_style=style)
@@ -59,7 +60,8 @@ class LinkTree:
         style = TreeStyle()
         style.show_leaf_name = False
         def my_layout(node):
-            node_style = TextFace(node.name, tight_text=True)
+            string_to_represent_node= "{} \n {}".format(node.name, node.webPageName)
+            node_style = TextFace(string_to_represent_node, tight_text=True)
             add_face_to_node(node_style, node, column=0, position='branch-bottom')
         style.layout_fn = my_layout
         self._tree.show(tree_style=style)
@@ -92,9 +94,10 @@ def initialize_tree(link, tld):
         root (ete3.Tree): root node of tree
         to_visit (list): Children of root node
     """
-    root = Tree(name=link)
+    root = CustomTree(name=link)
     html_content = read(link)
     soup = BeautifulSoup(html_content, 'html.parser')
+    root.webPageName=soup.title
     to_visit = get_urls_from_page(soup, extension=tld)
     return root, to_visit
 

--- a/modules/analyzer.py
+++ b/modules/analyzer.py
@@ -123,7 +123,7 @@ def build_tree(link, tld, stop=1, *, rec=0, to_visit=None, tree=None):
     if rec == 0:
         tree, to_visit = initialize_tree(link, tld)
 
-    sub_tree = Tree(name=tree.name)
+    sub_tree = CustomTree(name=tree.name, webPageName= tree.webPageName)
 
     if rec == stop:
         # If recursion is 0 then sub_tree will be root

--- a/modules/analyzer.py
+++ b/modules/analyzer.py
@@ -9,6 +9,13 @@ from ete3 import Tree, TreeStyle, TextFace, add_face_to_node
 from .getweblinks import get_urls_from_page
 from .pagereader import read
 
+
+class Node:
+    """Represents each webpage, has two attributes- one which has the url of the webpage and the other has the title (if mentioned) of the webpage """
+    def __init__(self, title="", link):
+        self.title=title 
+        self.link=link
+        
 class LinkTree:
     """
     This is a class that represents a tree of links within TorBot. This can be used to build a tree,


### PR DESCRIPTION
Issue #120 

### Changes Proposed
- a new datatype called CustomTree, which extends Tree. CustomTree has one  extra attribute called webPage Name
- changed the build_tree function to make a CustomTree instead of a Tree

- change the initialize_tree function to put soup.title value inside the CustomTree instance (which is being created instead of a Tree instance)
-change show() function and save() function to show  the webpage name and the url for each node

### Explanation of Changes
The basic concept is that, each node now also has the title of  the web page. This has been done by creating a new datatype which extends Tree and adds a new attribute called webPageName. 
@PSNAppz  @KingAkeem , the only problem is, that the formatting I've done is very rudimentary. It just uses basic python string formatting to display the url name and the web page name in two different lines. 


### Screenshots of new feature/change
