### PR TITLE
Updating requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.6.0
 PySocks==1.6.7
 termcolor==1.1.0
-requests==2.18.4
+requests==2.20.0
 requests_mock==1.4.0
 yattag==1.10.0
 pyinstaller==3.4.0


### PR DESCRIPTION
[Security Vulnerability in requests module]
 
## CVE-2018-18074 


### Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.