### PR TITLE
Allow using direct connection instead of SOCKS

### DIFF
--- a/torBot.py
+++ b/torBot.py
@@ -24,7 +24,7 @@ DEFPORT = 9050
 __VERSION = "1.3.3"
 
 
-def connect(address, port):
+def connect(address, port, no_socks):
     """ Establishes connection to port
 
     Assumes port is bound to localhost, if host that port is bound to changes
@@ -34,7 +34,8 @@ def connect(address, port):
         address (str): Address for port to bind to.
         port (str): Establishes connect to this port.
     """
-
+    if no_socks:
+        return
     if address and port:
         socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, address, port)
     elif address:
@@ -135,8 +136,7 @@ def main():
     TorBot's Core
     """
     args = get_args()
-    if not args.no_socks:
-        connect(args.ip, args.port)
+    connect(args.ip, args.port, args.no_socks)
 
     if args.gather:
         collect_data()

--- a/torBot.py
+++ b/torBot.py
@@ -125,7 +125,8 @@ def get_args():
                         help="Gather data for analysis")
     parser.add_argument("--no-socks",
                         action="store_true",
-                        help="Don't use local SOCKS. Useful when TorBot is launched behind a Whonix Gateway")
+                        help="Don't use local SOCKS. Useful when TorBot is"
+                             " launched behind a Whonix Gateway")
     return parser.parse_args()
 
 

--- a/torBot.py
+++ b/torBot.py
@@ -123,6 +123,9 @@ def get_args():
     parser.add_argument("--gather",
                         action="store_true",
                         help="Gather data for analysis")
+    parser.add_argument("--no-socks",
+                        action="store_true",
+                        help="Don't use local SOCKS. Useful when TorBot is launched behind a Whonix Gateway")
     return parser.parse_args()
 
 
@@ -131,7 +134,8 @@ def main():
     TorBot's Core
     """
     args = get_args()
-    connect(args.ip, args.port)
+    if not args.no_socks:
+        connect(args.ip, args.port)
 
     if args.gather:
         collect_data()


### PR DESCRIPTION
When TorBot is used in a VM with all its traffic going through Tor, like a Whonix Gateway (see https://www.qubes-os.org/doc/whonix/ and https://www.whonix.org/wiki/Qubes), there is no need to initialize a connection to Tor. In this case, allow to by-pass it from CLI. Please tell me if I overlooked it and missed something.