### PR TITLE
Use hiddenwiki.org as default URL for collecting data

### DIFF
--- a/src/modules/collect_data.py
+++ b/src/modules/collect_data.py
@@ -57,6 +57,8 @@ def get_links(url):
 
 
 default_url = 'https://thehiddenwiki.org'
+
+
 def collect_data(user_url):
     url = user_url if user_url is not None else default_url
     print(f"Gathering data for {url}")

--- a/src/modules/collect_data.py
+++ b/src/modules/collect_data.py
@@ -56,7 +56,9 @@ def get_links(url):
     return links
 
 
-def collect_data(url):
+default_url = 'https://thehiddenwiki.org'
+def collect_data(user_url):
+    url = user_url if user_url is not None else default_url
     print(f"Gathering data for {url}")
     links = get_links(url)
     # Create data directory if it doesn't exist


### PR DESCRIPTION
### Changes Proposed
- Use `thehiddenwiki.org` as the default URL for gathering data. 