### PR TITLE
Remove live flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ optional arguments:
   -v, --version         Show current version of TorBot.
   --update              Update TorBot to the latest stable version
   -q, --quiet           Prevent header from displaying
-  -u URL, --url URL     Specifiy a website link to crawl, currently returns links on that page (if used alone e.g. python3 torBot.py -u https://github.com)
+  -u URL, --url URL     Specifiy a website link to crawl, currently returns links on that page (if used alone e.g. python3 torBot.py -u https://www.github.com)
   -s, --save            Save results to a file in json format
   -m, --mail            Get e-mail addresses from the crawled sites
   -e EXTENSION, --extension EXTENSION

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ optional arguments:
   -v, --version         Show current version of TorBot.
   --update              Update TorBot to the latest stable version
   -q, --quiet           Prevent header from displaying
-  -u URL, --url URL     Specifiy a website link to crawl, currently returns links on that page
+  -u URL, --url URL     Specifiy a website link to crawl, currently returns links on that page (if used alone e.g. python3 torBot.py -u https://github.com)
   -s, --save            Save results to a file in json format
   -m, --mail            Get e-mail addresses from the crawled sites
   -e EXTENSION, --extension EXTENSION

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ An alternative way of running torBot is shown below, along with help instruction
 `python3 torBot.py or use the -h/--help argument`
 <pre>
 usage: torBot.py [-h] [-v] [--update] [-q] [-u URL] [-s] [-m] [-e EXTENSION]
-                 [-l] [-i]
+                 [-i]
 
 optional arguments:
   -h, --help            Show this help message and exit
@@ -112,7 +112,6 @@ optional arguments:
   -e EXTENSION, --extension EXTENSION
                         Specifiy additional website extensions to the
                         list(.com or .org etc)
-  -l, --live            Check if websites are live or not (slow)
   -i, --info            Info displays basic info of the scanned site (very
                         slow)` </pre>
 


### PR DESCRIPTION
### Explanation of Changes
The `-live` flag is no longer used since the default behavior of `torBot` is to display the "live" status of sites. This can be accomplished by just using the `-u` flag. 
