### PR TITLE
Save results as json

### DIFF
--- a/src/modules/link.py
+++ b/src/modules/link.py
@@ -45,10 +45,10 @@ def get_json_data(node):
     Returns:
         titles (list): List of Titles.
     """
-    json = []
+    json = [] 
     for anchor_tag in node._node.find_all('a'):
         link = anchor_tag.get('href')
-        json.append({"link":link,"tag":anchor_tag})
+        json.append({"link":link,"tag":anchor_tag.string})
     return json    
 
 

--- a/src/torBot.py
+++ b/src/torBot.py
@@ -169,11 +169,11 @@ def main():
             tree = LinkTree(node)
             file_name = str(input("File Name (.pdf/.png/.svg): "))
             tree.save(file_name)
+        if args.save:
+            print(node.get_json())
+            saveJson("Links", node.get_json())
         else:
             display_children(node)
-            if args.save:
-                print(node.get_json())
-                #saveJson("Links", node.links)
     else:
         print("usage: See torBot.py -h for possible arguments.")
 


### PR DESCRIPTION
Issue #196

### Changes Proposed
- Adds the ability to save the link tree as a JSON file
- If the tree is saved as a file then it will not be displayed within the terminal. 

### Explanation of Changes
- Saving as a file requires using the `-s` flag 