### PR TITLE
Improve gotor api wrapper

### DIFF
--- a/src/modules/api.py
+++ b/src/modules/api.py
@@ -10,8 +10,6 @@ class GoTor:
     """
     An API wrapper for the goTor service
     """
-
-
     def __init__(self, address='localhost', port='8081'):
         self._address = address
         self._port = port

--- a/src/modules/api.py
+++ b/src/modules/api.py
@@ -11,44 +11,43 @@ class GoTor:
     An API wrapper for the goTor service
     """
 
-    @staticmethod
-    def get_node(link, depth, address='localhost', port='8081'):
+    def __init__(self, address='localhost', port='8081'):
+        self._address = address
+        self._port = port
+        self._base_url = f'http://{address}:{port}'
+
+    def _format_url(self, endpoint):
+        return f'{self._base_url}{endpoint}'
+
+    def get_ip(self):
+        """
+        Returns the IP address of the current Tor client the service is using.
+        """
+        url = self._format_url('/ip')
+        resp = requests.get(url)
+        return resp.text
+
+
+    def get_node(self, link, depth):
         """
         Returns the LinkTree for the given link at the specified depth.
 
         Args:
             link (str): link to be used as a root node.
             depth (int): depth of the tree
-            address (str): network address
-            port (str): network port
         """
-        url = f'http://{address}:{port}/tree?link={link}&depth={depth}'
+        url = self._format_url(f'/tree?link={link}&depth={depth}')
         resp = requests.get(url)
         return resp.json()
 
-    @staticmethod
-    def get_ip(address='localhost', port='8081'):
-        """
-        Returns the IP address of the current Tor client the service is using.
 
-        Args:
-            address (str): network address
-            port (str): network port
-        """
-        url = f'http://{address}:{port}/ip'
-        resp = requests.get(url)
-        return resp.text
-
-    @staticmethod
-    def get_emails(link, address='localhost', port='8081'):
+    def get_emails(self, link):
         """
         Returns the mailto links found on the page.
 
         Args:
             link (str): the page to pull the emails from.
-            address (str): network address
-            port (str): network port
         """
-        url = f'http://{address}:{port}/emails?link={link}'
+        url = self._format_url(f'/emails?link={link}')
         resp = requests.get(url)
         return resp.json()

--- a/src/modules/api.py
+++ b/src/modules/api.py
@@ -11,6 +11,7 @@ class GoTor:
     An API wrapper for the goTor service
     """
 
+
     def __init__(self, address='localhost', port='8081'):
         self._address = address
         self._port = port
@@ -27,7 +28,6 @@ class GoTor:
         resp = requests.get(url)
         return resp.text
 
-
     def get_node(self, link, depth):
         """
         Returns the LinkTree for the given link at the specified depth.
@@ -39,7 +39,6 @@ class GoTor:
         url = self._format_url(f'/tree?link={link}&depth={depth}')
         resp = requests.get(url)
         return resp.json()
-
 
     def get_emails(self, link):
         """

--- a/src/modules/link_io.py
+++ b/src/modules/link_io.py
@@ -16,7 +16,7 @@ def print_tor_ip_address():
     displays your IP address which we scape and display
     """
     print('Attempting to connect to https://check.torproject.org/')
-    ip_string = color(GoTor.get_ip(), 'yellow')
+    ip_string = color(GoTor().get_ip(), 'yellow')
     print(f'Tor IP Address: {ip_string}')
 
 
@@ -57,7 +57,7 @@ def print_tree(url, depth=1):
         url (string): the url of the root node
         depth (int): the depth to build the tree
     """
-    root = GoTor.get_node(url, depth)
+    root = GoTor().get_node(url, depth)
     cascade(root, print_node)
 
 
@@ -72,7 +72,7 @@ def print_json(url, depth=1):
     Returns:
         root (dict): Dictionary containing the root node and it's children
     """
-    root = GoTor.get_node(url, depth)
+    root = GoTor().get_node(url, depth)
     pprint(root)
     return root
 
@@ -87,6 +87,6 @@ def print_emails(url):
     Returns:
         emails (list): list of emails
     """
-    email_list = GoTor.get_emails(url)
+    email_list = GoTor().get_emails(url)
     pprint(email_list)
     return email_list

--- a/src/modules/linktree.py
+++ b/src/modules/linktree.py
@@ -52,7 +52,7 @@ class LinkTree:
         Returns:
             tree (ete3.Tree): Built tree.
         """
-        root = GoTor.get_node(url, depth)
+        root = GoTor().get_node(url, depth)
         root_tree = Tree(name=root['url'])
         if root['children']:
             for child in root['children']:


### PR DESCRIPTION
- The address and port doesn't need to be passed for each call so now the values are being set within the constructor. 
- There's also a format url method to simplify adding new endpoints. 