### PR TITLE
Updated Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7-slim-buster
 LABEL maintainer="dedsec_inside"
 
 # Install PyQt5


### PR DESCRIPTION
Updated Dockerfile with python:3.7-slim-buster as the base image since python:3 is now based on bullseye, which causes dependency conflicts in poetry.

Issue #

### Changes Proposed
- 
- 
- 

### Explanation of Changes



### Screenshots of new feature/change
