### PR TITLE
Fix README `run.py` option `-l` to `-u`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Before you run the torBot make sure the following things are done properly:
 
 `poetry install` <-- to install dependencies
 
-`poetry run python run.py -l https://www.example.com --depth 2 -v` <-- example of running command with poetry
+`poetry run python run.py -u https://www.example.com --depth 2 -v` <-- example of running command with poetry
 
 `poetry run python run.py -h` <-- for help
 <pre>


### PR DESCRIPTION
Thank you for the excellent tool :) 
The command option in the README example was slightly different, so I fixed it.

### Changes Proposed
- Changed README command example as follows.
  - `run.py -l ...`  ... to `run.py -u ..` 

### Explanation of Changes
When I ran `run.py`with `-l` option(as described in the README), I got the following error(`unrecognized arguments: -l`)
```
...% poetry run python run.py -l https://www.example.com --depth 2 -v
usage: Gather and analayze data from Tor sites.
TorBot: error: unrecognized arguments: -l https://www.example.com
```

### Screenshots of new feature/change
When I ran `run.py` with `-u` option,  it worked.
```
...% poetry run python run.py -u https://www.example.com --depth 2 -v


                              __  ____  ____  __        ______
                             / /_/ __ \/ __ \/ /_  ____/_  __/
                            / __/ / / / /_/ / __ \/ __ \/ /
                           / /_/ /_/ / _, _/ /_/ / /_/ / /
                           \__/\____/_/ |_/_____/\____/_/  V2.1.0

                        #######################################################
                        #  TorBot - Dark Web OSINT Tool                       #
                        #  GitHub : https://github.com/DedsecInside/TorBot    #
                        #  Help : use -h for help text                        #
                        #######################################################
                                    LICENSE: GNU Public License v3

Attempting to connect to https://check.torproject.org/
26-Dec-22 23:03:21 - INFO - requesting http://localhost:8081/ip
```
I would appreciate it if you could review this.
Regards.