### PR TITLE
Adding documentation on how to use venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,22 @@
 ## Installation
 
 ### TorBot
+
+## Using `poetry`
 * TorBot dependencies are managed using `poetry`, you can find the installation commands below:
 ```sh
 poetry install # to install dependencies
 poetry run python torbot -u https://www.example.com --depth 2 --visualize tree --save json # example of running command with poetry
 poetry run python torbot -h # for help
+```
+
+## Using `venv`
+* If using Python ^3.4,
+```sh
+python -m venv torbot_venv
+source torbot_venv/bin/activate
+pip install -r requirements.txt
+python torbot -u https://www.example.com
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ### TorBot
 
-## Using `poetry`
+#### Using `poetry`
 * TorBot dependencies are managed using `poetry`, you can find the installation commands below:
 ```sh
 poetry install # to install dependencies
@@ -60,7 +60,7 @@ poetry run python torbot -u https://www.example.com --depth 2 --visualize tree -
 poetry run python torbot -h # for help
 ```
 
-## Using `venv`
+#### Using `venv`
 * If using Python ^3.4,
 ```sh
 python -m venv torbot_venv


### PR DESCRIPTION
TorBot can be ran using `venv` if you decide not to use `poetry`, adding instructions on how this can be done. 