### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,24 +9,24 @@ h11==0.16.0
 httpcore==1.0.9
 httpx[socks]==0.27.0
 idna==3.15
-igraph==0.11.4
+igraph>=0.11.4
 iniconfig==2.0.0
 joblib==1.4.2
 macholib==1.16.3
-numpy==1.26.4
+numpy>=1.26.4
 packaging==24.0
 pefile==2023.2.7 ; sys_platform == "win32"
 phonenumbers==8.13.37
 pluggy==1.5.0
 progress==1.6
 pyinstaller-hooks-contrib==2024.6
-pyinstaller==6.8.0
+pyinstaller>=6.8.0
 pysocks==1.7.1
 pytest==9.0.3
 python-dotenv==1.2.2
 pywin32-ctypes==0.2.2 ; sys_platform == "win32"
-scikit-learn==1.5.0
-scipy==1.13.0
+scikit-learn>=1.5.0
+scipy>=1.13.0
 setuptools==83.0.0
 six==1.16.0
 sniffio==1.3.1


### PR DESCRIPTION

### Summary

`requirements.txt` pins a 2024-era dependency matrix that **cannot be
installed on Python 3.13**:

- `igraph==0.11.4` — no cp313 wheel → meson source build fails
  (`Unknown compiler(s): [['icl'], ['cl'], ['cc'], ...]`)
- `numpy==1.26.4` — no cp313 wheel → source build fails (same meson error)
- `scipy==1.13.0`, `scikit-learn==1.5.0`, `pyinstaller==6.8.0` — no cp313
  distribution available

`pyproject.toml` already declares `"igraph>=0.11.4"` (unpinned), so
`pip install .` works while `pip install -r requirements.txt` is broken —
the two files disagree.

Fix: relax the upper-exact pins to lower bounds so pip can resolve
3.13-compatible releases:

```
igraph==0.11.4        →  igraph>=0.11.4
numpy==1.26.4         →  numpy>=1.26.4
scipy==1.13.0         →  scipy>=1.13.0
scikit-learn==1.5.0   →  scikit-learn>=1.5.0
pyinstaller==6.8.0    →  pyinstaller>=6.8.0
```

### Verification (Windows, Python 3.13.9)

- `igraph>=0.11.4` → **Successfully installed igraph-1.0.0** (cp313 wheel);
  `import igraph` OK
- `numpy==1.26.4` (before fix) → meson `Unknown compiler` error; after
  relaxation, `import numpy` resolves a 3.13-compatible build
- Full `pip install -r requirements.txt` is still blocked by the **remaining
  pinned matrix** (`ResolutionImpossible`, e.g. `pyinstaller-hooks-contrib==2024.6`
  vs newer pyinstaller) — the root cause is the repo-wide 2024 pin set, and a
  complete un-pin pass is recommended as a follow-up. This PR fixes the
  compile-blocking pins verified above.

### Files changed

- `requirements.txt` (5 pins relaxed)