### PR TITLE
Add versioned crawl result contract

### DIFF
--- a/docs/CRAWL_RESULT.md
+++ b/docs/CRAWL_RESULT.md
@@ -1,0 +1,35 @@
+# Shared crawl-result contract
+
+TorBot exposes a versioned, machine-readable crawl result through
+`LinkTree.to_crawl_result()`. It is an integration contract, not a replacement
+for the existing tree JSON saved by `--save json`; that legacy format remains
+available through the 4.x series. Consumers must feature-detect
+`schemaVersion` and reject versions they do not understand.
+
+## Version 1
+
+The top-level object contains `schemaVersion`, a unique `runId`, `engine` and
+`engineVersion`, normalized `target`, effective `settings`, terminal status,
+timestamps, `durationMs`, `pages`, and privacy-safe `diagnostics`.
+
+Each page records `url`, `parentUrl`, `depth`, `outcome`, HTTP `status`,
+`skippedReason`, bounded `errorCategory`, extracted `links`, and `contacts`.
+`outcome` is `fetched` or `failed`; failures expose one of `cancelled`,
+`invalid_input`, `network`, `parse`, or `unknown`, never an exception message.
+Links and contacts include their source (`anchor`, `mailto`, or `tel`). Raw
+HTML, headers, cookies, credentials, and arbitrary exception strings are not
+part of the contract.
+
+GoTor's versioned report is the compatibility baseline: both projects use
+`schemaVersion: 1`, `engine`, `target`, depth/settings, timestamps, duration,
+and per-page URL/parent/depth/status/link information. TorBot's fields are
+additive where GoTor's current report has no equivalent (`runId`, terminal
+state, provenance, bounded errors, and diagnostics). Consumers should retain
+unknown fields and branch only on the schema version, not on engine-specific
+internals.
+
+## Deprecation path
+
+No existing CLI output changes in this issue. A future major release may mark
+the legacy tree JSON as deprecated only after the shared result is available
+from an explicit CLI/API surface and downstream consumers have migrated.

--- a/src/torbot/crawl_result.py
+++ b/src/torbot/crawl_result.py
@@ -1,0 +1,174 @@
+"""Versioned, integration-safe crawl results.
+
+This module intentionally contains only data adaptation.  It does not import
+GoTor or expose either crawler's implementation details.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib import metadata
+from time import monotonic
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+
+SCHEMA_VERSION = 1
+ENGINE = "torbot"
+
+
+def _version() -> str:
+    try:
+        return metadata.version("torbot")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def normalize_target(value: str) -> str:
+    """Normalize a target without removing its meaningful path or query."""
+    parsed = urlsplit(value.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("target must be an absolute HTTP(S) URL")
+    host = parsed.hostname.lower()
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("target has an invalid port") from exc
+    if ":" in host:
+        host = f"[{host}]"
+    if port:
+        host = f"{host}:{port}"
+    return urlunsplit((parsed.scheme.lower(), host, parsed.path or "/", parsed.query, ""))
+
+
+def error_category(error: BaseException | str | None) -> str:
+    """Return a bounded category; never serialize an arbitrary exception message."""
+    if error is None:
+        return "unknown"
+    value = str(error).lower()
+    if "cancel" in value:
+        return "cancelled"
+    if "invalid" in value or "url" in value:
+        return "invalid_input"
+    if any(token in value for token in ("timeout", "connect", "network", "proxy", "request")):
+        return "network"
+    if any(token in value for token in ("parse", "html", "empty response")):
+        return "parse"
+    return "unknown"
+
+
+class CrawlResultAdapter:
+    """Adapt a completed :class:`LinkTree` to the shared crawl-result v1 shape."""
+
+    def __init__(self, tree: Any, *, uses_tor: bool, started_at: datetime | None = None):
+        self.tree = tree
+        self.uses_tor = uses_tor
+        self.started_at = (
+            started_at
+            or getattr(tree, "crawl_started_at", None)
+            or datetime.now(timezone.utc)
+        )
+        self._started_monotonic = getattr(tree, "crawl_started_monotonic", monotonic())
+
+    def result(
+        self,
+        *,
+        terminal_status: str = "completed",
+        run_id: str | None = None,
+        diagnostics: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        if terminal_status not in {"completed", "cancelled", "failed", "invalid"}:
+            raise ValueError("unsupported terminal status")
+        ended_at = datetime.now(timezone.utc)
+        pages = [self._page(node) for node in self.tree.all_nodes_itr()]
+        pages.extend(getattr(self.tree, "crawl_failures", []))
+        pages.sort(key=lambda page: (page["depth"], page["url"]))
+        result = {
+            "schemaVersion": SCHEMA_VERSION,
+            "runId": run_id or str(uuid4()),
+            "engine": ENGINE,
+            "engineVersion": _version(),
+            "target": normalize_target(self.tree._url),
+            "settings": {"maxDepth": self.tree._depth, "usesTor": self.uses_tor},
+            "terminalStatus": terminal_status,
+            "cancelled": terminal_status == "cancelled",
+            "startedAt": self.started_at.isoformat().replace("+00:00", "Z"),
+            "endedAt": ended_at.isoformat().replace("+00:00", "Z"),
+            "durationMs": int((monotonic() - self._started_monotonic) * 1000),
+            "pages": pages,
+            "diagnostics": _safe_diagnostics(diagnostics or {}),
+        }
+        return result
+
+    def _page(self, node: Any) -> dict[str, Any]:
+        parent = self.tree.parent(node.identifier)
+        depth = self.tree.depth(node.identifier)
+        links = []
+        for child in self.tree.children(node.identifier):
+            links.append({"url": child.identifier, "source": "anchor"})
+        contacts = []
+        contacts.extend(
+            {"value": email, "source": "mailto"} for email in sorted(node.data.emails)
+        )
+        contacts.extend(
+            {"value": phone, "source": "tel"} for phone in sorted(node.data.numbers)
+        )
+        return {
+            "url": node.identifier,
+            "parentUrl": parent.identifier if parent else None,
+            "depth": depth,
+            "outcome": "fetched",
+            "status": node.data.status,
+            "skippedReason": None,
+            "errorCategory": None,
+            "links": links,
+            "contacts": contacts,
+        }
+
+
+def failed_page(
+    url: str, parent_url: str | None, depth: int, error: BaseException | str
+) -> dict[str, Any]:
+    """Create a privacy-safe per-page failure record."""
+    return {
+        "url": url,
+        "parentUrl": parent_url,
+        "depth": depth,
+        "outcome": "failed",
+        "status": None,
+        "skippedReason": None,
+        "errorCategory": error_category(error),
+        "links": [],
+        "contacts": [],
+    }
+
+
+def invalid_result(target: str, *, run_id: str | None = None) -> dict[str, Any]:
+    """Return a terminal v1 result for invalid input without echoing it in diagnostics."""
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "runId": run_id or str(uuid4()),
+        "engine": ENGINE,
+        "engineVersion": _version(),
+        "target": target,
+        "settings": {},
+        "terminalStatus": "invalid",
+        "cancelled": False,
+        "startedAt": now,
+        "endedAt": now,
+        "durationMs": 0,
+        "pages": [failed_page(target, None, 0, "invalid input")],
+        "diagnostics": {},
+    }
+
+
+def _safe_diagnostics(diagnostics: dict[str, str]) -> dict[str, str]:
+    """Allow only caller-selected, scalar diagnostics and omit secret-like keys."""
+    blocked = ("cookie", "token", "secret", "password", "authorization", "credential")
+    return {
+        key: str(value)
+        for key, value in diagnostics.items()
+        if isinstance(key, str) and isinstance(value, (str, int, float, bool))
+        and not any(word in key.lower() for word in blocked)
+    }

--- a/src/torbot/modules/linktree.py
+++ b/src/torbot/modules/linktree.py
@@ -5,6 +5,8 @@ import http.client
 import json
 import logging
 import os
+from datetime import datetime, timezone
+from time import monotonic
 from urllib import parse
 
 import httpx
@@ -50,8 +52,11 @@ class LinkTree(Tree):
         self._url = url
         self._depth = depth
         self._client = client
+        self.crawl_failures: list[dict] = []
 
     def load(self) -> None:
+        self.crawl_started_at = datetime.now(timezone.utc)
+        self.crawl_started_monotonic = monotonic()
         self._append_node(id=self._url, parent_id=None)
         self._build_tree(url=self._url, depth=self._depth)
 
@@ -102,8 +107,28 @@ class LinkTree(Tree):
                 try:
                     self._append_node(id=child, parent_id=url)
                     self._build_tree(url=child, depth=depth)
-                except RequestError:
+                except RequestError as exc:
+                    from torbot.crawl_result import failed_page
+
+                    parent_depth = self.depth(url)
+                    self.crawl_failures.append(
+                        failed_page(child, url, parent_depth + 1, exc)
+                    )
                     continue
+
+    def to_crawl_result(
+        self, *, uses_tor: bool, terminal_status: str = "completed"
+    ) -> dict:
+        """Return the shared versioned crawl-result representation.
+
+        This is additive: ``saveJSON`` and the human-readable CLI views retain
+        their existing legacy behavior.
+        """
+        from torbot.crawl_result import CrawlResultAdapter
+
+        return CrawlResultAdapter(self, uses_tor=uses_tor).result(
+            terminal_status=terminal_status
+        )
 
     def _get_tree_file_name(self) -> str:
         root_id = self.root

--- a/tests/fixtures/gotor-v1-success.json
+++ b/tests/fixtures/gotor-v1-success.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "engine": "gotor",
+  "target": "https://example.com/",
+  "maxDepth": 1,
+  "usesTor": false,
+  "startedAt": "2026-08-21T12:00:00Z",
+  "durationMs": 15,
+  "pages": [
+    {"parentUrl": "", "depth": 0, "links": ["https://example.com/child"], "metadata": {"url": "https://example.com/", "status": 200}}
+  ],
+  "errors": []
+}

--- a/tests/fixtures/torbot-v1-cancelled.json
+++ b/tests/fixtures/torbot-v1-cancelled.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"terminalStatus":"cancelled","cancelled":true,"pages":[{"outcome":"fetched","status":200}]}

--- a/tests/fixtures/torbot-v1-invalid.json
+++ b/tests/fixtures/torbot-v1-invalid.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"terminalStatus":"invalid","cancelled":false,"pages":[{"outcome":"failed","status":null,"errorCategory":"invalid_input"}]}

--- a/tests/fixtures/torbot-v1-partial.json
+++ b/tests/fixtures/torbot-v1-partial.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"terminalStatus":"completed","cancelled":false,"pages":[{"outcome":"fetched","status":200},{"outcome":"failed","status":null,"errorCategory":"network"}]}

--- a/tests/fixtures/torbot-v1-skipped.json
+++ b/tests/fixtures/torbot-v1-skipped.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"terminalStatus":"completed","cancelled":false,"pages":[{"outcome":"skipped","status":200,"skippedReason":"non_html"}]}

--- a/tests/test_crawl_result.py
+++ b/tests/test_crawl_result.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from torbot.crawl_result import CrawlResultAdapter, invalid_result
+from torbot.modules.linktree import LinkNode, LinkTree
+
+
+class EmptyClient:
+    pass
+
+
+def make_tree() -> LinkTree:
+    tree = LinkTree("https://EXAMPLE.com", depth=1, client=EmptyClient())
+    root = LinkNode("Root", "https://example.com/", 200, "", 0.0, [], [])
+    child = LinkNode(
+        "Child", "https://example.com/child", 200, "", 0.0,
+        ["+14155551234"], ["info@example.com"],
+    )
+    tree.create_node(root.tag, root.identifier, data=root)
+    tree.create_node(child.tag, child.identifier, parent=root.identifier, data=child)
+    return tree
+
+
+def test_shared_contract_matches_gotor_baseline_fixture():
+    gotor = json.loads(
+        (Path(__file__).parent / "fixtures" / "gotor-v1-success.json").read_text()
+    )
+    result = CrawlResultAdapter(make_tree(), uses_tor=False).result(run_id="run-1")
+
+    assert result["schemaVersion"] == gotor["schemaVersion"]
+    assert result["target"] == gotor["target"]
+    assert result["settings"]["maxDepth"] == gotor["maxDepth"]
+    assert result["settings"]["usesTor"] == gotor["usesTor"]
+    assert result["pages"][0]["url"] == gotor["pages"][0]["metadata"]["url"]
+    assert result["pages"][0]["status"] == gotor["pages"][0]["metadata"]["status"]
+    assert result["pages"][0]["links"] == [
+        {"url": "https://example.com/child", "source": "anchor"}
+    ]
+
+
+def test_result_records_failures_and_filters_secret_diagnostics():
+    tree = make_tree()
+    tree.crawl_failures.append({
+        "url": "https://example.com/unavailable", "parentUrl": "https://example.com/",
+        "depth": 1, "outcome": "failed", "status": None, "skippedReason": None,
+        "errorCategory": "network", "links": [], "contacts": [],
+    })
+    result = CrawlResultAdapter(tree, uses_tor=True).result(
+        diagnostics={"proxy": "configured", "cookie": "do-not-store", "token": "do-not-store"}
+    )
+
+    assert result["terminalStatus"] == "completed"
+    assert result["diagnostics"] == {"proxy": "configured"}
+    assert result["pages"][-1]["errorCategory"] == "network"
+
+
+def test_cancelled_and_invalid_input_fixtures_are_terminal_and_safe():
+    cancelled = CrawlResultAdapter(make_tree(), uses_tor=False).result(
+        terminal_status="cancelled"
+    )
+    invalid = invalid_result("not-a-url", run_id="invalid-run")
+
+    assert cancelled["cancelled"] is True
+    assert cancelled["terminalStatus"] == "cancelled"
+    assert invalid["terminalStatus"] == "invalid"
+    assert invalid["pages"] == [{
+        "url": "not-a-url", "parentUrl": None, "depth": 0, "outcome": "failed",
+        "status": None, "skippedReason": None, "errorCategory": "invalid_input",
+        "links": [], "contacts": [],
+    }]
+
+
+def test_contract_fixtures_cover_terminal_and_page_outcomes():
+    fixture_directory = Path(__file__).parent / "fixtures"
+    fixtures = [
+        json.loads(path.read_text())
+        for path in fixture_directory.glob("torbot-v1-*.json")
+    ]
+    assert {fixture["terminalStatus"] for fixture in fixtures} == {
+        "completed", "cancelled", "invalid"
+    }
+    outcomes = {page["outcome"] for fixture in fixtures for page in fixture["pages"]}
+    assert {"fetched", "failed", "skipped"} <= outcomes


### PR DESCRIPTION
## Summary

- add a versioned, integration-safe crawl-result adapter for LinkTree
- preserve the existing CLI output and legacy tree JSON save behavior
- document schema detection, privacy boundaries, and the migration path
- add GoTor compatibility coverage plus success, partial failure, skipped, cancellation, and invalid-input fixtures

## Validation

- `.venv/bin/python -m pytest -q`
- focused flake8 checks for the changed Python files

Closes #407