### PR TITLE
ci: modernize Python test matrix and GitHub Actions

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,26 +1,33 @@
 name: Flake8
 
-on: [push]
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
     - name: Analysing the code with flake8
-      run: |
-        flake8 --per-file-ignores="__init__.py:F401" .
+      run: flake8 --per-file-ignores="__init__.py:F401" .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Pytest
 
 on:
@@ -13,22 +10,28 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          requirements.txt
+          pyproject.toml
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        python -m pip install -r requirements.txt
+        python -m pip install --no-deps -e .
     - name: Test with pytest
-      run: |
-        pytest
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ### Dependencies
 - Tor (Optional)
-- Python 3.9+
+- Python 3.10+
 - pip
 
 ## Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,9 @@ authors = [
 ]
 description = "TorBot is an OSINT tool for the dark web."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Issue #404

### Changes Proposed
- Test and lint the project on Python 3.10, 3.11, and 3.12.
- Update GitHub Actions and pin them to full commit SHAs.
- Enable pip caching and run both workflows for pull requests targeting `dev`.

### Explanation of Changes

Python 3.9 was removed because the current dependencies require Python 3.10 or newer.

Actions are pinned to full SHAs for reproducibility and security.

`fail-fast: false` ensures every Python version is tested even if one fails.


### Screenshots of new feature/change
